### PR TITLE
Fixed compiler error in files ICel.cs and ReanimatorState.cs

### DIFF
--- a/Runtime/Cels/ICel.cs
+++ b/Runtime/Cels/ICel.cs
@@ -4,7 +4,7 @@ namespace Aarthificial.Reanimation.Cels
 {
     public interface ICel
     {
-        public void ApplyToRenderer(
+        void ApplyToRenderer(
             ReanimatorState previousState,
             ReanimatorState nextState,
             SpriteRenderer renderer

--- a/Runtime/ReanimatorState.cs
+++ b/Runtime/ReanimatorState.cs
@@ -8,15 +8,15 @@ namespace Aarthificial.Reanimation
 {
     public interface IReadOnlyReanimatorState : IEnumerable<KeyValuePair<string, int>>
     {
-        public void Set(string name, bool value);
+        void Set(string name, bool value);
 
-        public int Get(string name, int fallback = 0);
+        int Get(string name, int fallback = 0);
 
-        public float GetFloat(string name, float fallback = 0);
+        float GetFloat(string name, float fallback = 0);
 
-        public bool GetBool(string name, bool fallback = false);
+        bool GetBool(string name, bool fallback = false);
 
-        public bool ShouldFlip();
+        bool ShouldFlip();
     }
 
     [Serializable]


### PR DESCRIPTION
In the above mentioned files all public modifiers were removed from the interfaces inside, the reason being they caused the compiler error CS0106.